### PR TITLE
cleanup generated config parameters

### DIFF
--- a/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.prop
+++ b/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.prop
@@ -5,3 +5,4 @@ solace_vpn=NeedToOverride
 solace_host=NeedToOverride
 solace_authentication_type=BASIC
 ExceptionLogging=false
+ReferenceID=IFlow Reference ID

--- a/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.propdef
+++ b/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.propdef
@@ -11,6 +11,15 @@
   </parameter>
   <parameter>
     <key/>
+    <name>ReferenceID</name>
+    <type>xsd:string</type>
+    <isRequired>false</isRequired>
+    <constraint/>
+    <description>IFlow Reference ID to include in enhanced exception logging</description>
+    <additionalMetadata/>
+  </parameter>
+  <parameter>
+    <key/>
     <name>solace_host</name>
     <type>xsd:string</type>
     <isRequired>false</isRequired>
@@ -57,25 +66,15 @@
     <additionalMetadata/>
   </parameter>
   <param_references>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::password" attribute_uilabel="Password Secure Alias" param_key="solace_password_alias"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::messageVpn" attribute_uilabel="Message VPN" param_key="solace_vpn"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::host" attribute_uilabel="Host" param_key="solace_host"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::authenticationType" attribute_uilabel="Authentication Type" param_key="solace_authentication_type"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::username" attribute_uilabel="Username" param_key="solace_username"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::password" attribute_uilabel="Password Secure Alias" param_key="solace_password_alias"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::messageVpn" attribute_uilabel="Message VPN" param_key="solace_vpn"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::host" attribute_uilabel="Host" param_key="solace_host"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::authenticationType" attribute_uilabel="Authentication Type" param_key="solace_authentication_type"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::username" attribute_uilabel="Username" param_key="solace_username"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::password" attribute_uilabel="Password Secure Alias" param_key="solace_password_alias"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::messageVpn" attribute_uilabel="Message VPN" param_key="solace_vpn"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::host" attribute_uilabel="Host" param_key="solace_host"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::authenticationType" attribute_uilabel="Authentication Type" param_key="solace_authentication_type"/>
-    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::username" attribute_uilabel="Username" param_key="solace_username"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::password" attribute_uilabel="Password Secure Alias" param_key="solace_password_alias"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::messageVpn" attribute_uilabel="Message VPN" param_key="solace_vpn"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::host" attribute_uilabel="Host" param_key="solace_host"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::authenticationType" attribute_uilabel="Authentication Type" param_key="solace_authentication_type"/>
-    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::SolacePubSubPlus/vendor::Solace/version::1.2.0/attrId::username" attribute_uilabel="Username" param_key="solace_username"/>
+    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::password" attribute_uilabel="Password Secure Alias" param_key="solace_password_alias"/>
+    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::messageVpn" attribute_uilabel="Message VPN" param_key="solace_vpn"/>
+    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::host" attribute_uilabel="Host" param_key="solace_host"/>
+    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::authenticationType" attribute_uilabel="Authentication Type" param_key="solace_authentication_type"/>
+    <reference attribute_category="EventMeshSender" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::username" attribute_uilabel="Username" param_key="solace_username"/>
+    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::password" attribute_uilabel="Password Secure Alias" param_key="solace_password_alias"/>
+    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::messageVpn" attribute_uilabel="Message VPN" param_key="solace_vpn"/>
+    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::host" attribute_uilabel="Host" param_key="solace_host"/>
+    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::authenticationType" attribute_uilabel="Authentication Type" param_key="solace_authentication_type"/>
+    <reference attribute_category="EventMeshReceiver" attribute_id="ctype::Adapter/cname::AdvancedEventMesh/vendor::SAP/version::1.3.0/attrId::username" attribute_uilabel="Username" param_key="solace_username"/>
   </param_references>
 </parameters>


### PR DESCRIPTION
- Removed duplicate parameters and changed adaptor referenced by parameter attributes to AdvancedEventMesh version 1.3
- Added `ReferencedID` parameter
- underlying code generator updated to include `Initialize Parameters` content modifier to pick up values of `ExceptionLogging` and `ReferenceID` externalized parameters
