### PR TITLE
remove ReferenceId from external parameters

### DIFF
--- a/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.prop
+++ b/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.prop
@@ -5,4 +5,3 @@ solace_vpn=NeedToOverride
 solace_host=NeedToOverride
 solace_authentication_type=BASIC
 ExceptionLogging=false
-ReferenceID=IFlow Reference ID

--- a/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.propdef
+++ b/src/main/resources/static/iflowdocument-template/src/main/resources/parameters.propdef
@@ -11,15 +11,6 @@
   </parameter>
   <parameter>
     <key/>
-    <name>ReferenceID</name>
-    <type>xsd:string</type>
-    <isRequired>false</isRequired>
-    <constraint/>
-    <description>IFlow Reference ID to include in enhanced exception logging</description>
-    <additionalMetadata/>
-  </parameter>
-  <parameter>
-    <key/>
     <name>solace_host</name>
     <type>xsd:string</type>
     <isRequired>false</isRequired>


### PR DESCRIPTION
Remove ReferenceId from externalized parameters. This value is referenced in the exception groovy script. The value will be set at run-time, not configured at deployment.